### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,10 +8,10 @@ Subile: Download subtitles from the terminal
 .. image:: https://coveralls.io/repos/marcwebbie/subile/badge.png
    :target: https://coveralls.io/r/marcwebbie/subile
    :alt: Test Coverage
-.. image:: https://pypip.in/version/subile/badge.svg?text=version
+.. image:: https://img.shields.io/pypi/v/subile.svg?label=version
    :target: https://pypi.python.org/pypi/subile/
    :alt: Version
-.. image:: https://pypip.in/py_versions/subile/badge.svg
+.. image:: https://img.shields.io/pypi/pyversions/subile.svg
    :target: https://pypi.python.org/pypi/subile/
    :alt: Supported Python versions
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20subile))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `subile`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.